### PR TITLE
Updated WIP_organize_text.py

### DIFF
--- a/radiocarbon_code/WIP_organize_text.py
+++ b/radiocarbon_code/WIP_organize_text.py
@@ -380,8 +380,8 @@ validAgeSearchList = [
     '%',
     'yr', 
     'yrs',
-    'C14',
-    'C13',
+    'c14',
+    'c13',
     'modern',
     'contemporary',
     'older than',
@@ -509,7 +509,7 @@ for subDir, dirs, files in os.walk(sourceDir):
                                 lastDataRemoved = 'materialDated'
                                 skipPop = 1
                                 continue
-                        if re.search('(lab[^a]?)|(univ)|(u.s.)|(geol.sur)|(unit[^ed])|(packardinstrument)|(inst)', trimLine):
+                        if re.search('(lab[^a]?)|(univ)|(u\.s\.)|(geol.sur)|(unit[^ed])|(packardinstrument)|(inst)', trimLine): #Louisiana
                             if 'labName' in dataList:
                                 possibleLabNum = re.search('[0-9a-zA-Z\-]{1,4}-(\d){1,4}', line)
                                 if possibleLabNum != None:
@@ -523,7 +523,7 @@ for subDir, dirs, files in os.walk(sourceDir):
                                 lastDataRemoved = 'labName'
                                 skipPop = 1
                                 continue
-                        if any(item in line for item in validAgeSearchList) and all(item not in lowerLine for item in invalidAgeSearchList):
+                        if any(item in lowerLine for item in validAgeSearchList) and all(item not in lowerLine for item in invalidAgeSearchList):
                             if 'age' in dataList:
                                 #this check was added since labNumber is commonly read
                                 #on the same line as the age (or labName)
@@ -586,7 +586,7 @@ for subDir, dirs, files in os.walk(sourceDir):
                                 elif re.search('(lat)-+', trimLine):
                                     latitude = "Unlocated"
                                     longitude = "Unlocated"
-                                elif 'long' not in trimLine:
+                                elif 'lo' not in trimLine:
                                     latitude = latLongFunc(trimLine, 0)
                                     skipPop = 1
                                     continue


### PR DESCRIPTION
Changed the age if statement to check lowercase lines, since it was missing a lot of instances of "Modern", my bad. The u.s. was also causing problems in the lab name, since . is a special character in regex. You'd think with me constantly pulling up the Web3 page I would know that, haha. Also shortened a string in the latLong area. There's a set of if statements meant to catch when Lat and Long are separated onto two different lines by checking if "long" or "lat" are missing in the string (in that order). There was a LOT of cases where it would not find "long" because the OCR messed up, causing "long" to turn into "loi^" or any other jumble of characters that was not "long". Shortened to "lo", which got rid of a lot of errors. This _shouldn't_ cause false positives since it still has to go through the regex before it checks for "lo", but it's hard to check that sort of thing.